### PR TITLE
Add :program option to render/pod2man methods

### DIFF
--- a/lib/Pod/To/Man.rakumod
+++ b/lib/Pod/To/Man.rakumod
@@ -134,9 +134,9 @@ multi method pod-node(Any $pod) {
     die "Unknown POD element of type '" ~ $pod.^name ~ "': " ~ $pod.raku
 }
 
-method pod2man($pod) {
+method pod2man($pod, Str:D :$program = $*PROGRAM.basename) {
     my $*POD2MAN-NESTING = 0;
-    qq«.pc\n.TH {$*PROGRAM.basename} 1 {Date.today}\n»
+    qq«.pc\n.TH $program 1 {Date.today}\n»
         ~ self.para-ctx: { self.pod-node($pod) }
 }
 
@@ -144,6 +144,6 @@ method pod2roff($pod) {
     self.para-ctx: { self.pod-node($pod) }
 }
 
-method render($pod) {
-    self.pod2man($pod);
+method render($pod, Str:D :$program = $*PROGRAM.basename) {
+    self.pod2man($pod, :program($program));
 }

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -1,7 +1,7 @@
 use Test;
 use Pod::To::Man;
 
-plan 9;
+plan 11;
 
 =begin pod
 =head1 NAME
@@ -72,5 +72,11 @@ say $roff;
 like $roff, /^^ 'Entering text\\&.' .* 'Level 1\\&.1' .* 'Level 2\\&.1' .* 'Big item' .* 'A nested item' .* 'definition'/, "all expected text is in place";
 like $roff, /'Level 1\\&.1'\n \.RS .* 'Level 2\\&.1' .* \.RE/, "level items are rendered with indentation";
 like $roff, /'Big item' \n \.IP \n 'with few paragraphs' \n \.IP \n \.RS .* \.IP .* 'A nested item' \n \.IP \n 'with paragraphs'/, 'nested multiparagraph items';
+
+lives-ok {
+    $roff = Pod::To::Man.render($=pod[0], :program('program'));
+}, "pod renders with custom program ok";
+
+ok $roff.contains('.TH program'), "has the header with custom program";
 
 done-testing;


### PR DESCRIPTION
Currently, render/pod2man use the basename of the $*PROGRAM object as the name for the generated manual page. This may not be desired behavior in some situations, like when the executable file does not share the same name as the file containing the pod. This commit adds the ':program' parameter to render/pod2man, allowing the user to override the manpage program name.