### PR TITLE
Determine manpage name from pod contents

### DIFF
--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -1,12 +1,12 @@
 use Test;
 use Pod::To::Man;
 
-plan 11;
+plan 13;
 
 =begin pod
 =head1 NAME
 
-Test
+Test - Some test pod
 
 =head1 SYNOPSIS
 
@@ -52,13 +52,23 @@ text
 
 =end pod
 
+=begin pod
+
+=NAME Test
+
+=HEAD1 SYNOPSIS
+
+  yada yada...
+
+=end pod
+
 my $roff;
 
 lives-ok {
     $roff = Pod::To::Man.render($=pod[0]);
 }, "first pod renders ok";
 
-ok $roff.contains('.TH 01-basic.rakutest'), "has the header";
+ok $roff.contains('.TH Test'), "has the header";
 ok $roff.contains("\n.SH NAME"), "NAME heading";
 like $roff, /Test .* \.SH \s SYNOPSIS .* Example\: .*/, "no text lost";
 like $roff, /\.EX .* code \s is \s here/, "code is rendered";
@@ -78,5 +88,11 @@ lives-ok {
 }, "pod renders with custom program ok";
 
 ok $roff.contains('.TH program'), "has the header with custom program";
+
+lives-ok {
+    $roff = Pod::To::Man.render($=pod[2])
+}, "third pod renders ok";
+
+ok $roff.contains('.TH Test'), "has the header specified by =NAME";
 
 done-testing;


### PR DESCRIPTION
This PR adds functionality to Pod::To::Man that allows it to automatically determine the name of the generated manpage from the contents of its pod. It does this by scanning the pod for '=head1 NAME' or '=NAME' blocks and extracting the program name from them. If it cannot determine the program name from the pod, it will default to the value of $*PROGRAM.basename.