### PR TITLE
Add method for handling comments

### DIFF
--- a/lib/Pod/To/Man.rakumod
+++ b/lib/Pod/To/Man.rakumod
@@ -141,6 +141,11 @@ multi method pod-node(Pod::FormattingCode $pod) {
     }
 
 }
+
+multi method pod-node(Pod::Block::Comment:D $pod) {
+    Empty;
+}
+
 multi method pod-node(Str:D $pod) {
     escape($pod);
 }

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -1,9 +1,16 @@
 use Test;
 use Pod::To::Man;
 
-plan 13;
+plan 14;
 
 =begin pod
+
+=begin comment
+Comments
+shouldn't
+render
+=end comment
+
 =head1 NAME
 
 Test - Some test pod
@@ -72,6 +79,7 @@ ok $roff.contains('.TH Test'), "has the header";
 ok $roff.contains("\n.SH NAME"), "NAME heading";
 like $roff, /Test .* \.SH \s SYNOPSIS .* Example\: .*/, "no text lost";
 like $roff, /\.EX .* code \s is \s here/, "code is rendered";
+unlike $roff, /Comments .* shouldn\'t .* render/, "comments are not rendered";
 
 lives-ok {
     $roff = Pod::To::Man.render($=pod[1]);


### PR DESCRIPTION
Pod::To::Man currently has no method for dealing with Pod comments. This PR adds adds a comment method that just returns `Empty`.